### PR TITLE
Notification when change the role

### DIFF
--- a/src/controller/events.js
+++ b/src/controller/events.js
@@ -19,18 +19,20 @@ async function onChange(action = () => {}) {
 
       action(change);
     } else {
-      player.renameRoles(obrChange);
-      for (let i = 0; i < obrChange.length; i++) {
-        for (let j = 0; j < change.onlinePlayers.length; j++) {
-          if (obrChange[i].id === change.onlinePlayers[j].id) {
-            if (obrChange[i].role !== change.onlinePlayers[j].role) {
-              change.diffPlayer = obrChange[i];
-              change.changeType = "CHANGE-ROLE";
+      for (let i = 0; i < change.onlinePlayers.length; i++) {
+        const player = change.onlinePlayers[i];
+
+        for (let j = 0; j < change.newOnlinePlayers.length; j++) {
+          const newPlayer = change.newOnlinePlayers[j];
+          if (player.id == newPlayer.id) {
+            if (player.name !== newPlayer.name) {
+              change.changeType = "RENAME";
+              change.diffPlayer = newPlayer;
               action(change);
             }
-            if (obrChange[i].name !== change.onlinePlayers[j].name) {
-              change.diffPlayer = obrChange[i];
-              change.changeType = "RENAME";
+            if (player.role !== newPlayer.role) {
+              change.changeType = "CHANGE-ROLE";
+              change.diffPlayer = newPlayer;
               action(change);
             }
           }

--- a/src/controller/events.js
+++ b/src/controller/events.js
@@ -44,8 +44,29 @@ async function onChange(action = () => {}) {
 }
 
 async function onMetadataChange(action = () => {}) {
+  let metadata = await model.metadata.get();
   OBR.room.onMetadataChange((change) => {
-    action(change[model.METADATA_PATH]);
+    const newMetadata = change[model.METADATA_PATH];
+
+    if (metadata.players.length !== newMetadata.players.length) {
+      metadata = newMetadata;
+      action(change[model.METADATA_PATH]);
+    } else {
+      for (let i = 0; i < newMetadata.players.length; i++) {
+        if (metadata.players[i].name !== newMetadata.players[i].name) {
+          metadata = newMetadata;
+          action(change[model.METADATA_PATH]);
+        }
+        if (metadata.players[i].role !== newMetadata.players[i].role) {
+          metadata = newMetadata;
+          action(change[model.METADATA_PATH]);
+        }
+        if (metadata.players[i].state !== newMetadata.players[i].state) {
+          metadata = newMetadata;
+          action(change[model.METADATA_PATH]);
+        }
+      }
+    }
   });
 }
 


### PR DESCRIPTION
## DONE
now the function onMetadataChange only calls the callback if the change is directly on the Romitor-ex metadata, ignoring other extensions metadata